### PR TITLE
fix message-id bug

### DIFF
--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -42,6 +42,15 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
         parser = HeaderParser()
         headers = parser.parsestr(file_data)
 
+        # headers is a Message object implementing magic methods of set/get item and contains.
+        # message object 'contains' method transforms its keys to lower-case, hence there is not a difference when
+        # approaching it with any casing type, for example, 'message-id' or 'Message-ID' or 'Message-id' or
+        # 'MeSSage_Id' are all searching for the same key in the headers object.
+        if "message-id" in headers:
+            message_id_content = headers["message-id"]
+            del headers["message-id"]
+            headers["Message-ID"] = message_id_content
+
         header_list = []
         headers_map = {}  # type: dict
         for item in headers.items():

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -8,6 +8,7 @@ from parse_emails.handle_msg import (DataModel, MsOxMessage,
                                      create_headers_map, get_msg_mail_format,
                                      handle_msg)
 from parse_emails.parse_emails import EmailParser
+from parse_emails.handle_eml import handle_eml
 
 
 def test_parse_emails():
@@ -594,3 +595,17 @@ def test_double_dots_removed():
     results = EmailParser(file_path=test_path, max_depth=1, parse_only_headers=False, file_info=test_type)
     results.parse()
     assert 'http://schemas.microsoft.com/office/2004/12/omml' in results.parsed_email['HTML']
+
+
+def test_handle_eml_parses_correct_message_id():
+    """
+    Given:
+     - eml file
+    When:
+     - parsing eml file into email data.
+    Then:
+     - Validate that correct 'Message-ID' case sensitive is in 'HeadersMap' dict.
+       Must be 'Message-ID' case sensitive.
+    """
+    email_data, _ = handle_eml(file_path='test_data/invalid_message_id.eml')
+    assert 'Message-ID' in email_data['HeadersMap']

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -3,12 +3,11 @@ from __future__ import print_function
 
 import pytest
 
-from parse_emails.handle_eml import unfold
+from parse_emails.handle_eml import handle_eml, unfold
 from parse_emails.handle_msg import (DataModel, MsOxMessage,
                                      create_headers_map, get_msg_mail_format,
                                      handle_msg)
 from parse_emails.parse_emails import EmailParser
-from parse_emails.handle_eml import handle_eml
 
 
 def test_parse_emails():

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -606,5 +606,5 @@ def test_handle_eml_parses_correct_message_id():
      - Validate that correct 'Message-ID' case sensitive is in 'HeadersMap' dict.
        Must be 'Message-ID' case sensitive.
     """
-    email_data, _ = handle_eml(file_path='test_data/invalid_message_id.eml')
+    email_data, _ = handle_eml(file_path='parse_emails/tests/test_data/invalid_message_id.eml')
     assert 'Message-ID' in email_data['HeadersMap']

--- a/parse_emails/tests/test_data/invalid_message_id.eml
+++ b/parse_emails/tests/test_data/invalid_message_id.eml
@@ -1,0 +1,18 @@
+Subject: Subject
+Mime-Version: 1.0 (Mac OS X Mail 14.0 \(3654.10.10.10.10\))
+Content-Type: text/html;
+	charset=us-ascii
+X-Apple-Base-Url: x-msg://3/
+X-Universally-Unique-Identifier: AA11AA1A-A111-411A-1A1A-AAAA11A11AAA
+X-Apple-Mail-Remote-Attachments: YES
+From: "qqqqq@test.org First,
+ Last" <1111@test.org>
+X-Apple-Windows-Friendly: 1
+Date: Wed, 10 Nov 2021 11:13:24 +0200
+X-Apple-Mail-Signature:
+Content-Transfer-Encoding: 7bit
+Message-id: <AAAA11A1-11AA-11A1-AA11-1111A1A11111@example.com>
+X-Uniform-Type-Identifier: com.apple.mail-draft
+To: xxxx@gmail.com
+
+<html><head></head><body dir="auto" style="word-wrap: break-word; -webkit-nbsp-mode: space; line-break: after-white-space;"></body></html>


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://github.com/demisto/etc/issues/45913

## Description
This PR fixes an issue that when parsing EML files, there is a message-id field that is not mapped correctly to the context output.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [x] Tests
- [ ] Documentation
