### PR TITLE
Handle SMTP Envelope Headers

### DIFF
--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -27,7 +27,7 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
         return None, []
 
     with open(file_path, 'rb') as emlFile:
-
+        handle_SMTP_headers(emlFile)
         file_data = emlFile.read()
         if b64:
             file_data = b64decode(file_data)
@@ -294,6 +294,21 @@ def decode_content(mime):
         payload = mime.get_payload()
         if isinstance(payload, str):
             return payload
+
+
+def handle_SMTP_headers(emlFile):
+    """
+    Remove the transfer headers attached to the eml file by the SMTP protocol. The function reads the lines of the input
+    eml file until a line which isn't an SMTP header is reached.
+    """
+    SMTP_HEADERS = ['MAIL FROM', 'RCPT TO', 'DATA']
+    remove_smtp_header = True
+    while remove_smtp_header:
+        pos = emlFile.tell()
+        line = emlFile.readline()
+        if not any(smtp_header in str(line) for smtp_header in SMTP_HEADERS):
+            remove_smtp_header = False
+            emlFile.seek(pos)
 
 
 def mime_decode(word_mime_encoded):

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -64,6 +64,17 @@ def test_eml_smtp_type():
     assert results.parsed_email['Subject'] == 'Test Smtp Email'
 
 
+def test_eml_smtp_envelope_headers():
+    test_path = 'parse_emails/tests/test_data/smtp_envelope_headers.eml'
+    test_type = 'SMTP mail, UTF-8 Unicode text, with CRLF terminators'
+
+    results = EmailParser(file_path=test_path, max_depth=3, parse_only_headers=False, file_info=test_type)
+    results.parse()
+
+    assert isinstance(results.parsed_email, dict)
+    assert results.parsed_email['Subject'] == 'Test Smtp Email'
+
+
 # this is a test for another version of a multipart signed eml file
 def test_smime2():
 

--- a/parse_emails/tests/test_data/smtp_envelope_headers.eml
+++ b/parse_emails/tests/test_data/smtp_envelope_headers.eml
@@ -1,0 +1,22 @@
+MAIL FROM:<test@smtpserver.com>
+RCPT TO:<user1@smtpserver.com>
+Return-Path: <test@test.com>
+X-Original-To: user1@test.com
+Delivered-To: user1@test.com
+Received: from [10.19.120.67] (unknown [10.19.120.67])
+	by test.com (Postfix) with ESMTPA id F3B4A40055
+	for <user1@test.com>; Wed, 23 Jan 2019 18:55:56 +0100 (CET)
+To: user1@test.com
+From: "test@test.com" <test@test.com>
+Subject: Test Smtp Email
+Message-ID: <5b4831d0-5322-ea23-6312-864ff419a1f1@test.com>
+Date: Wed, 23 Jan 2019 18:55:56 +0100
+User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64; rv:60.0) Gecko/20100101
+ Thunderbird/60.4.0
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8; format=flowed
+Content-Transfer-Encoding: 8bit
+Content-Language: en-US
+
+This is a test smtp type email
+


### PR DESCRIPTION
## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-13573

## Description
Fixes an issue where the handle_eml function would fail in case the eml file contained SMTP envelope headers such as `MAIL FROM` and `RCPT TO`

## Must have
- [x] Tests

