### PR TITLE
Fixed a bug in parsing rtf compressed msg files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+v0.0.14
+* Fixed an issue where extracting the RTF body from msg emails failed.
+
 v0.0.13
 * Fixed an issue where signed .p7m files were not recognized.
 * Added the option to pass in the filename.

--- a/parse_emails/handle_msg.py
+++ b/parse_emails/handle_msg.py
@@ -780,8 +780,8 @@ class Message(object):
         """
             Replaces control characters within the text with their RTF encoded versions \\'HH.
 
-            This function is a temporary hack - should be removed when version 0.0.3 of the RTFDE.deencapsulate package
-            is released.
+            This function is a temporary hack (https://github.com/seamustuohy/RTFDE/issues/5#issuecomment-1095355075) -
+            should be removed when version 0.0.3 of the RTFDE.deencapsulate package is released.
         """
         cleaned = \
             rtf_body.replace(b'\\\\', b"\\'5c").replace(b'\\{', b"\\'7b").replace(b'\\}', b"\\'7d").replace(b'\\~', b"")

--- a/parse_emails/handle_msg.py
+++ b/parse_emails/handle_msg.py
@@ -779,11 +779,12 @@ class Message(object):
     def _simplify_text_for_rtf_parsing(rtf_body):
         """
             Replaces control characters within the text with their RTF encoded versions \\'HH.
+
+            This function is a temporary hack - should be removed when version 0.0.3 of the RTFDE.deencapsulate package
+            is released.
         """
-        cleaned = rtf_body.replace(b'\\\\', b"\\'5c")
-        cleaned = cleaned.replace(b'\\{', b"\\'7b")
-        cleaned = cleaned.replace(b'\\}', b"\\'7d")
-        cleaned = cleaned.replace(b'\\~', b"")
+        cleaned = \
+            rtf_body.replace(b'\\\\', b"\\'5c").replace(b'\\{', b"\\'7b").replace(b'\\}', b"\\'7d").replace(b'\\~', b"")
         return cleaned
 
     def _set_properties(self):
@@ -848,6 +849,8 @@ class Message(object):
             if compressed_rtf:
                 compressed_rtf_body = property_values['RtfCompressed']
                 rtf_body = compressed_rtf.decompress(compressed_rtf_body)
+                # Need to remove the following row and the _simplify_text_for_rtf_parsing() func when version 0.0.3 of
+                # the RTFDE.deencapsulate package is released.
                 rtf_body = self._simplify_text_for_rtf_parsing(rtf_body)
                 from RTFDE.deencapsulate import DeEncapsulator
                 rtf_obj = DeEncapsulator(rtf_body)

--- a/parse_emails/handle_msg.py
+++ b/parse_emails/handle_msg.py
@@ -775,6 +775,17 @@ class Message(object):
 
         return None
 
+    @staticmethod
+    def _simplify_text_for_rtf_parsing(rtf_body):
+        """
+            Replaces control characters within the text with their RTF encoded versions \\'HH.
+        """
+        cleaned = rtf_body.replace(b'\\\\', b"\\'5c")
+        cleaned = cleaned.replace(b'\\{', b"\\'7b")
+        cleaned = cleaned.replace(b'\\}', b"\\'7d")
+        cleaned = cleaned.replace(b'\\~', b"")
+        return cleaned
+
     def _set_properties(self):
         property_values = self.properties
 
@@ -837,6 +848,7 @@ class Message(object):
             if compressed_rtf:
                 compressed_rtf_body = property_values['RtfCompressed']
                 rtf_body = compressed_rtf.decompress(compressed_rtf_body)
+                rtf_body = self._simplify_text_for_rtf_parsing(rtf_body)
                 from RTFDE.deencapsulate import DeEncapsulator
                 rtf_obj = DeEncapsulator(rtf_body)
                 rtf_obj.deencapsulate()


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [XSUP-17612](https://jira-hq.paloaltonetworks.local/browse/XSUP-17612).

## Description
In the related issue, there is an email (msg file) that fails the scripts. 
The exception is raised in the code of RTFDE.deencapsulate package that we use to read RTF compressed mails. 
It seems like a known problem in the RTFDE.deencapsulate package - [link to the open issue](https://github.com/seamustuohy/RTFDE/issues/5). I asked there about the status of a fix. 
In the meantime, I used a hack (published in their issue) to temporarily overcome the problem. 
Using this hack the file is now parsed successfully (the rtf is parsed to a valid HTML file).  

This fix should be temporary - when version 0.0.3 of the RTFDE.deencapsulate package is released we should revert this fix and try to use the updated package instead. 
@moishce - Let's discuss the best way to remember to do this.

I wanted to add a unit test with the bug's .msg file, but I couldn't remove the metadata of the file (didn't want to expose the customer's data).  


## Must have
- [ ] Tests
- [ ] Documentation
