### PR TITLE
deprecate the support for embed the image in HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 v0.1.11
-* Deprecate the support for cid-embedded images in EML files.
+* Deprecate the support for cid-embedded images in EML and MSG files.
 
 v0.1.10
 * Fixed an issue where the html in a msg will return as bytes and when doing the in search in *_embed_images_to_html_body* we get an error because we try to search a string in bytes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+v0.1.91
+* Deprecate the support for cid-embedded images in EML files.
+
 v0.1.9
 * Fixed an issue where an eml file containing non ascii characters was not decoded correctly.
 

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -263,36 +263,6 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
         return email_data, attached_emails
 
 
-def embed_images_to_html_body(html, attachments_images):
-    """
-    Embed images into the HTML body by changing the src of the image to the image content in base64
-
-    Args:
-        html (str): the HTML of the email.
-        attachments_images (List(tuple[str, str])): a list of tuples containing attachment IDs and the image content in
-            base64.
-
-    https://sendgrid.com/blog/embedding-images-emails-facts/
-
-    Returns:
-        str: the HTML embedded with images.
-    """
-    if '<img' not in html:
-        return html
-
-    for attachment_id, image_base64 in attachments_images:
-        if attachment_id:  # in p7m files types we can have png files without an attachment ID.
-            attachment_id = re.sub('<|>', '', attachment_id)  # remove < and > from the attachment-ID.
-            # '<image001.jpg@01D8B147.CFCD4400>' --> image001.jpg@01D8B147.CFCD4400
-            image_base64 = re.sub('\n|\r', '', image_base64)  # remove escaping chars
-            attachment_cid_pattern = f'src="cid:{attachment_id}"'
-            if attachment_cid_pattern in html:
-                html = html.replace(
-                    attachment_cid_pattern, f'src="data:image/jpeg;base64,{image_base64}"'
-                )
-    return html
-
-
 def unfold(s):
     r"""
     Remove folding whitespace from a string by converting line breaks (and any

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -230,9 +230,6 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
             elif part.get_content_type() == 'text/plain':
                 text = decode_content(part)
 
-        if attachments_images and html:  # embed images into the HTML body.
-            html = embed_images_to_html_body(html=html, attachments_images=attachments_images)
-
         email_data = None
         # if we are parsing a signed attachment there can be one of two options:
         # 1. it is 'multipart/signed' so it is probably a wrapper and we can ignore the outer "email"

--- a/parse_emails/handle_msg.py
+++ b/parse_emails/handle_msg.py
@@ -478,19 +478,6 @@ class Message:
         self._set_properties()
         self._set_attachments()
         self._set_recipients()
-        self._embed_images_to_html_body()
-
-    def _embed_images_to_html_body(self):
-        # embed images into html body
-        if self.attachments and self.html:
-            for attachment in self.attachments:
-                html_content = self.html
-                if isinstance(html_content, bytes):
-                    html_content = html_content.decode('utf-8')
-                if attachment.AttachContentId and f'src="cid:{attachment.AttachContentId}"' in html_content:
-                    img_base64 = base64.b64encode(attachment.data).decode('ascii')
-                    self.html = self.html.replace(f'src="cid:{attachment.AttachContentId}"',
-                                                  f'src="data:image/png;base64, {img_base64}"')
 
     def _get_attachments_names(self):
         names = []

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -1,4 +1,3 @@
-import base64
 
 import pytest
 

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -684,7 +684,6 @@ def test_rtf_msg():
     email_parser = EmailParser(file_path=test_path)
     results = email_parser.parse()
     assert '<html xmlns:v="urn:schemas-microsoft-com:vml"' in results['HTML']
-    assert 'src="data:image/png;base64, ' in results['HTML']
 
 
 def test_eml_with_attachment_with_no_name():

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from parse_emails.handle_eml import handle_eml, unfold

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -706,25 +706,6 @@ def test_eml_with_attachment_with_no_name():
     assert 'VMail Enclosed for John Smith' in results['Subject']
 
 
-def test_embedding_image_into_html_of_eml():
-    """
-    Given:
-     - eml file containing images as CID (and contains HTML)
-
-    When:
-     - parsing eml file into email data.
-
-    Then:
-     - Validate that the src of the img tag contains the file in base64
-    """
-    test_path = 'parse_emails/tests/test_data/eml_contains_image_as_cid.eml'  # contains image.jpg as an attachment to the eml file.
-    email_parser = EmailParser(file_path=test_path)
-    results = email_parser.parse()
-    with open('parse_emails/tests/test_data/image.jpg', 'rb') as f:
-        base64_img = base64.b64encode(f.read()).decode('ascii')
-        assert f'src="data:image/jpeg;base64,{base64_img}"' in results['HTML']
-
-
 @pytest.mark.parametrize('data_value, data_type, expected_value',
                          [(b'\x01', '0x0002', 1),
                           (b'\x01', '0x0003', 1),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parse-emails"
-version = "0.1.10"
+version = "0.1.11"
 description = "Parses an email message file and extracts the data from it."
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/okta_login.jsp?RelayState=%2Fbrowse%2FCRTX-81822
content PR: https://github.com/demisto/content/pull/26945

## Description
currently, when we parse an EML file - the base64 of  inline image is embedded in the returned HTML
this are wrong as the HTML become huge field and lead to some issues