### PR TITLE
Decode attachment file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+v0.1.13
+* Fixed an issue where an attachment file name with special characters was not decoded correctly.
+
 v0.1.12
 * Fixed an issue where a Subject containing special characters was not decoded correctly.
 

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -377,7 +377,7 @@ def extract_address_eml(eml, entry):
 def get_attachment_filename(part):
     attachment_file_name = None
     if part.get_filename():
-        attachment_file_name = str(decode_header(make_header(part.get_filename())))
+        attachment_file_name = str(make_header(decode_header(part.get_filename())))
 
     elif attachment_file_name is None and part.get('filename'):
         attachment_file_name = os.path.normpath(part.get('filename'))

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -8,9 +8,9 @@ import re
 import tempfile
 from base64 import b64decode
 from email import message_from_string
+from email.header import decode_header, make_header
 from email.parser import HeaderParser
 from email.utils import getaddresses
-from email.header import decode_header, make_header
 
 from parse_emails.common import convert_to_unicode
 from parse_emails.handle_msg import handle_msg

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -10,6 +10,7 @@ from base64 import b64decode
 from email import message_from_string
 from email.parser import HeaderParser
 from email.utils import getaddresses
+from email.header import decode_header, make_header
 
 from parse_emails.common import convert_to_unicode
 from parse_emails.handle_msg import handle_msg
@@ -376,7 +377,7 @@ def extract_address_eml(eml, entry):
 def get_attachment_filename(part):
     attachment_file_name = None
     if part.get_filename():
-        attachment_file_name = part.get_filename()
+        attachment_file_name = str(decode_header(make_header(part.get_filename())))
 
     elif attachment_file_name is None and part.get('filename'):
         attachment_file_name = os.path.normpath(part.get('filename'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parse-emails"
-version = "0.1.12"
+version = "0.1.13"
 description = "Parses an email message file and extracts the data from it."
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/XSUP-26219

## Description
Decode attachment file name using the decode_header and make_header functions
For more info see [here](https://stackoverflow.com/questions/7331351/python-email-header-decoding-utf-8#answer-21715870)

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
