### PR TITLE
S/MIME files without to/from/subject fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 v0.1.14
-* Fixed an issue where attachments were not being saved to the war room when users attempted to upload S/MIME files that lacked the To/From/Subject fields.
+* Fixed an issue where the parsed_email didn't contain the email wrapper and its AttachmentsData in cases of S/MIME files that lacked the To, From, and Subject fields.
 
 v0.1.13
 * Fixed an issue where an attachment file name with special characters was not decoded correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+v0.1.14
+* Fixed an issue where attachments were not being saved to the war room when users attempted to upload S/MIME files that lacked the To/From/Subject fields.
 
 v0.1.13
 * Fixed an issue where an attachment file name with special characters was not decoded correctly.

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -238,8 +238,8 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
         # 2. if it is 'multipart/signed' but has 'to'/'from'/'subject' fields, so it is actually a real mail.
         if 'multipart/signed' not in eml.get_content_type() \
             or ('multipart/signed' in eml.get_content_type() and
-                ((extract_address_eml(eml, 'to') or extract_address_eml(eml, 'from') or eml.get('subject'))
-                 or attachment_names)):
+                ((extract_address_eml(eml, 'to') or extract_address_eml(eml, 'from') or eml.get('subject')) or
+                 attachment_names)):
             email_data = {
                 'To': extract_address_eml(eml, 'to'),
                 'CC': extract_address_eml(eml, 'cc'),

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -233,11 +233,13 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
 
         email_data = None
         # if we are parsing a signed attachment there can be one of two options:
-        # 1. it is 'multipart/signed' so it is probably a wrapper and we can ignore the outer "email"
-        # 2. if it is 'multipart/signed' but has 'to' address so it is actually a real mail.
+        # 1. it is 'multipart/signed' so it is probably a wrapper, and we can ignore the outer "email"
+        #    However, we should save its AttachmentsData.
+        # 2. if it is 'multipart/signed' but has 'to'/'from'/'subject' fields, so it is actually a real mail.
         if 'multipart/signed' not in eml.get_content_type() \
-                or ('multipart/signed' in eml.get_content_type() and
-                    (extract_address_eml(eml, 'to') or extract_address_eml(eml, 'from') or eml.get('subject'))):
+            or ('multipart/signed' in eml.get_content_type() and
+                ((extract_address_eml(eml, 'to') or extract_address_eml(eml, 'from') or eml.get('subject'))
+                 or attachment_names)):
             email_data = {
                 'To': extract_address_eml(eml, 'to'),
                 'CC': extract_address_eml(eml, 'cc'),
@@ -291,7 +293,7 @@ def decode_content(mime):
             elif charset == 'iso-8859-2':
                 return payload.decode('iso-8859-2')
             elif charset == 'utf-8':
-                return payload.decode('utf-8')
+                return payload.decode('utf-8', errors='ignore')
             elif charset in ('gb2312', 'gb18030'):  # chinese encodings
                 return payload.decode('gb18030')
             elif charset == 'iso-2022-jp':

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -104,8 +104,10 @@ def test_smime_entity_ascii_crlf():
     results = EmailParser(file_path=test_path, max_depth=3, parse_only_headers=False, file_info=test_type)
     results.parse()
 
-    assert isinstance(results.parsed_email, dict)
-    assert results.parsed_email['Subject'] == 'Testing Email Attachment'
+    assert isinstance(results.parsed_email, list)
+    assert results.parsed_email[0]['Subject'] is None
+    assert isinstance(results.parsed_email[0]['AttachmentsData'], list)
+    assert results.parsed_email[0]['AttachmentNames'] == ['smime.p7s', 'Attachment.eml']
 
 
 def test_eml_contains_eml():
@@ -333,8 +335,10 @@ def test_smime():
     results = EmailParser(file_path=test_path, max_depth=3, parse_only_headers=False, file_info=test_type)
     results.parse()
 
-    assert isinstance(results.parsed_email, dict)
-    assert results.parsed_email['Subject'] == 'Testing Email Attachment'
+    assert isinstance(results.parsed_email, list)
+    assert results.parsed_email[0]['Subject'] is None
+    assert isinstance(results.parsed_email[0]['AttachmentsData'], list)
+    assert results.parsed_email[0]['AttachmentNames'] == ['smime.p7s', 'Attachment.eml']
 
 
 def test_smime_msg():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parse-emails"
-version = "0.1.13"
+version = "0.1.14"
 description = "Parses an email message file and extracts the data from it."
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-26184)
Related PR: [link to the PR at demisto/content](https://github.com/demisto/content/pull/28442)
Related PR: [link to the PR at demisto//dockerfiles](https://github.com/demisto/dockerfiles/pull/18220)

## Description
* Fixed an issue where the parsed_email didn't contain the email wrapper and its AttachmentsData in cases of S/MIME files that lacked the To, From, and Subject fields.

If an email is of type 'multipart/signed' but does not have the 'to', 'from', or 'subject' fields, it will not enter the if condition to save the 'AttachmentsData' in the 'email_data' variable. As a result, when using the 'ParseEmailFilesV2' script and the attachments will not be saved to the war-room because they were not included in the 'AttachmentsData' field.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
