### PR TITLE
parse image without disposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+v0.1.15
+* Fixed an issue where inline image without *Content-Disposition* header did not parsed.
+
 v0.1.14
 * Fixed an issue where the parsed_email didn't contain the email wrapper and its AttachmentsData in cases of S/MIME files that lacked the To, From, and Subject fields.
 

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -192,9 +192,6 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
                             attachment_content.append(None)
                         # fileResult will return an error if file_content is None.
                         if file_content and not attachment_file_name.endswith('.p7s'):
-                            # base64 of embeded image
-                            if "base64" in part.get("Content-Transfer-Encoding", ""):
-                                file_content = b64decode(file_content)
                             attachment_content.append(file_content)
                             if attachment_file_name.endswith(('.png', '.jpg', '.jpeg', '.gif')):
                                 attachments_images.append((attachment_content_id, part.get_payload().strip()))

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -100,7 +100,7 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
                 parts += [part_ for part_ in part.get_payload() if isinstance(part_, email.message.Message)]
 
             elif part.get_filename()\
-                or "attachment" in part.get("Content-Disposition", "")
+                or "attachment" in part.get("Content-Disposition", "")\
                 or part.get("X-Attachment-Id"):
 
                 attachment_content_id = part.get('Content-ID')

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -100,8 +100,8 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
                 parts += [part_ for part_ in part.get_payload() if isinstance(part_, email.message.Message)]
 
             elif part.get_filename()\
-                or "attachment" in part.get("Content-Disposition", "")\
-                or part.get("X-Attachment-Id"):
+                    or "attachment" in part.get("Content-Disposition", "")\
+                    or part.get("X-Attachment-Id"):
 
                 attachment_content_id = part.get('Content-ID')
                 attachment_content_disposition = part.get('Content-Disposition')

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -99,7 +99,9 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
                     and "attachment" not in part.get("Content-Disposition", ""):
                 parts += [part_ for part_ in part.get_payload() if isinstance(part_, email.message.Message)]
 
-            elif part.get_filename() or "attachment" in part.get("Content-Disposition", ""):
+            elif part.get_filename()\
+                or "attachment" in part.get("Content-Disposition", "")
+                or part.get("X-Attachment-Id"):
 
                 attachment_content_id = part.get('Content-ID')
                 attachment_content_disposition = part.get('Content-Disposition')
@@ -190,6 +192,9 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
                             attachment_content.append(None)
                         # fileResult will return an error if file_content is None.
                         if file_content and not attachment_file_name.endswith('.p7s'):
+                            # base64 of embeded image
+                            if "base64" in part.get("Content-Transfer-Encoding", ""):
+                                file_content = b64decode(file_content)
                             attachment_content.append(file_content)
                             if attachment_file_name.endswith(('.png', '.jpg', '.jpeg', '.gif')):
                                 attachments_images.append((attachment_content_id, part.get_payload().strip()))
@@ -386,7 +391,9 @@ def get_attachment_filename(part):
         if os.path.isabs(attachment_file_name):
             attachment_file_name = os.path.basename(attachment_file_name)
     else:
-        if not isinstance(part.get_payload(), list):
+        if attach_id := part.get("X-Attachment-Id"):
+            attachment_file_name = attach_id
+        elif not isinstance(part.get_payload(), list):
             attachment_file_name = 'unknown_file_name'
         else:
             for payload in part.get_payload():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parse-emails"
-version = "0.1.14"
+version = "0.1.15"
 description = "Parses an email message file and extracts the data from it."
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
## Related Issues
related: https://jira-hq.paloaltonetworks.local/browse/XSUP-26948

## Description
in case the inline image doesn't have the `Content-Disposition` we missed it

for example:
```
--===============7999012100669325336==
Content-Transfer-Encoding: base64
Content-ID: <ii_3b4a62f6>
X-Attachment-Id: ii_3b4a62f6
Content-Type: image/png; filename="ii_3b4a62f6"
```

passed pytest:
<img width="1424" alt="image" src="https://github.com/demisto/parse-emails/assets/79846863/d486c4d1-d83e-46ca-8267-8619220f4170">

