### PR TITLE
[XSUP-27106] email.utils.getaddresses() returns incorrect value in email address part of tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
+v0.1.16
+* Fixed an issue where the email address fields were not extracted properly.
+
 v0.1.15
-* Fixed an issue where inline image without *Content-Disposition* header did not parsed.
+* Fixed an issue where inline image without *Content-Disposition* header did not parse.
 
 v0.1.14
 * Fixed an issue where the parsed_email didn't contain the email wrapper and its AttachmentsData in cases of S/MIME files that lacked the To, From, and Subject fields.

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -355,7 +355,7 @@ def get_email_address(eml, entry):
         gel_all_values_from_email_by_entry = eml.get_all(entry, [])
     addresses = getaddresses(gel_all_values_from_email_by_entry)
     if addresses:
-        res = [item[1] for item in addresses]
+        res = [email_address for real_name, email_address in addresses if "@" in email_address]
         res = ', '.join(res)
         return res
     return ''

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -159,6 +159,17 @@ def test_eml_contains_eml_depth():
 
 
 def test_eml_utf_text():
+    """
+    Given:
+        EML file containing a 'From' field in the following structure: "From: Test TEST, test<test@test.com>"
+    When:
+        parsing the email
+    Then:
+        assert it is parsed correctly.
+        parsed_email['From'] == 'test@test.com' and != 'Test, test@test.com'
+        TODO: When a fix is released: https://github.com/python/cpython/issues/107919
+              the conditional check 'if "@"' in the get_email_address function can be removed.
+    """
 
     test_path = 'parse_emails/tests/test_data/utf_8_email.eml'
     test_type = 'UTF-8 Unicode text, with very long lines, with CRLF line terminators'
@@ -168,6 +179,8 @@ def test_eml_utf_text():
 
     assert isinstance(results.parsed_email, dict)
     assert results.parsed_email['Subject'] == 'Test UTF Email'
+    assert results.parsed_email['From'] == 'test@test.com'
+    assert results.parsed_email['To'] == 'test@test.com'
 
 
 def test_eml_utf_text_special_chars():

--- a/parse_emails/tests/test_data/utf_8_email.eml
+++ b/parse_emails/tests/test_data/utf_8_email.eml
@@ -1,5 +1,5 @@
 To: test@test.com
-From: "test@test.com" <test@test.com>
+From: Test TEST, test<test@test.com>
 Subject: Test UTF Email
 Message-ID: <5b4831d0-5322-ea23-6312-864ff419a1f1@test.com>
 Date: Wed, 23 Jan 2019 18:55:56 +0100


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-27106)
Opened [bug](https://github.com/python/cpython/issues/107919) for [cpython](https://github.com/python/cpython) library

## Description
Fixed an issue where the email address fields were not extracted properly.

```
EML file contains: 
From: Test TEST, test<test@test.com>

in previous version: results.parsed_email['From'] = 'Test, test@test.com'
in this version: results.parsed_email['From'] = 'test@test.com'
```


## Must have
- [ ] Tests
- [ ] Documentation
