### PR TITLE
Adding *Macintosh HFS*  to the supported file eml types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 v0.1.16
+* Fixed an issue where *Macintosh HFS* file type got "Unknown file format" while parsing.
+
+v0.1.16
 * Fixed an issue where the email address fields were not extracted properly.
 
 v0.1.15

--- a/parse_emails/parse_emails.py
+++ b/parse_emails/parse_emails.py
@@ -89,7 +89,7 @@ class EmailParser:
                 output = create_email_output(email_data, attached_emails)
 
             elif any(eml_candidate in file_type_lower for eml_candidate in
-                     ['rfc 822 mail', 'smtp mail', 'multipart/signed', 'multipart/alternative', 'multipart/mixed',
+                     ['macintosh hfs', 'rfc 822 mail', 'smtp mail', 'multipart/signed', 'multipart/alternative', 'multipart/mixed',
                       'message/rfc822', 'application/pkcs7-mime', 'multipart/related', 'utf-8 (with bom) text']):
                 if 'unicode (with bom) text' in file_type_lower or 'utf-8 (with bom) text' in file_type_lower:
                     self._bom = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parse-emails"
-version = "0.1.16"
+version = "0.1.17"
 description = "Parses an email message file and extracts the data from it."
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
## Status
- [x] In Progress

## Related Issues
relates: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-27133?filter=-1)

## Description
Bug explanation: 
In the described [bug](https://jira-hq.paloaltonetworks.local/browse/XSUP-27133) the customer uploaded an eml file of type Macintosh HFS.
The parse-email didn't support *Macintosh HFS*, therefore, parsing this kind of file was failing.

Solution:
I am adding Macintosh HFS to the supported file eml types. 

## Screenshots
Paste here any images that will help the reviewer.
