### PR TITLE
parse-emails: better fix for inline images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+v0.1.18
+* Fixed an issue where inline image did not parse.
+
 v0.1.17
 * Fixed an issue where several unicode spaces weren't parsed as expected.
 

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -101,7 +101,7 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
 
             elif part.get_filename()\
                     or "attachment" in part.get("Content-Disposition", "")\
-                    or part.get("X-Attachment-Id"):
+                    or ("image" in part.get("Content-Type") and part.get("Content-Transfer-Encoding") == "base64"):
 
                 attachment_content_id = part.get('Content-ID')
                 attachment_content_disposition = part.get('Content-Disposition')

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -101,6 +101,7 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
 
             elif part.get_filename()\
                     or "attachment" in part.get("Content-Disposition", "")\
+                    or part.get("X-Attachment-Id")\
                     or ("image" in part.get("Content-Type", '') and part.get("Content-Transfer-Encoding") == "base64"):
 
                 attachment_content_id = part.get('Content-ID')

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -101,7 +101,7 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
 
             elif part.get_filename()\
                     or "attachment" in part.get("Content-Disposition", "")\
-                    or ("image" in part.get("Content-Type") and part.get("Content-Transfer-Encoding") == "base64"):
+                    or ("image" in part.get("Content-Type", '') and part.get("Content-Transfer-Encoding") == "base64"):
 
                 attachment_content_id = part.get('Content-ID')
                 attachment_content_disposition = part.get('Content-Disposition')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parse-emails"
-version = "0.1.17"
+version = "0.1.18"
 description = "Parses an email message file and extracts the data from it."
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION


## Related Issues
related: https://jira-hq.paloaltonetworks.local/browse/XSUP-26948

## Description
the original fix was dedicated to specific case of inline base64 image with `X-Attachment-Id` header
the current fix will extract each image with the `Content-Transfer-Encoding: base64`


