### PR TITLE
Release new version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parse-emails"
-version = "0.1.25"
+version = "0.1.26"
 description = "Parses an email message file and extracts the data from it."
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
Release a new version for parse-emails after [this fix](https://github.com/demisto/parse-emails/pull/87) was merged.