### PR TITLE
Msg files: handle From email address that not comply with the RFC 5322 standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+v0.1.30
+* Fixed an issue where email addresses with commas in the display name were not parsed correctly.
+
 v0.1.28
 * Fixed an issue where attachment file name encoded in windows-874 could not be parsed correctly.
 

--- a/parse_emails/handle_msg.py
+++ b/parse_emails/handle_msg.py
@@ -55,6 +55,7 @@ from parse_emails.constants import (DEFAULT_ENCODING, PROPS_ID_MAP,
 logger = logging.getLogger('parse_emails')
 
 MIME_ENCODED_WORD = re.compile(r'(.*)=\?(.+)\?([B|Q])\?(.+)\?=(.*)')  # guardrails-disable-line
+emailRegex = r'''(?i)(?:[a-z0-9!#$%&'*+/=?^_\x60{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_\x60{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])'''  # noqa: E501
 
 DATA_TYPE_MAP = {
     "0x0000": "PtypUnspecified",
@@ -1056,10 +1057,28 @@ def parse_email_headers(header, raw=False):
         "BCC": [],
         "Reply-To": [],
     }
-
+    format_issue = False
     for addr in email_address_headers.keys():
-        for (name, email_address) in email.utils.getaddresses(headers.get_all(addr, [])):
-            email_address_headers[addr].append(f"{name} <{email_address}>")
+        address_header = headers.get_all(addr, [])
+        email_addresses = email.utils.getaddresses(address_header)
+
+        # This workaround addresses an issue with email addresses that have a comma in the display name
+        # but are not enclosed in quotation marks. In such cases, the email.utils.getaddresses function
+        # fails to parse the address correctly, as it expects display names with special characters
+        # (like commas) to be wrapped in quotes, according to RFC 5322.
+        if addr == 'From' and len(email_addresses) > 1:
+            for (name, email_address) in email_addresses:
+                # If email.utils.getaddresses returns a list, we check the email addresses returned.
+                # If any of them contain invalid email addresses, we remove them and keep only the valid ones.
+                if not re.findall(emailRegex, email_address):
+                    format_issue = True
+                    email_addresses.remove((name, email_address))
+
+        for (name, email_address) in email_addresses:
+            if format_issue:
+                email_address_headers[addr].append(f"<{email_address}>")
+            else:
+                email_address_headers[addr].append(f"{name} <{email_address}>")
 
     parsed_headers = dict(headers)
     parsed_headers.update(email_address_headers)

--- a/parse_emails/handle_msg.py
+++ b/parse_emails/handle_msg.py
@@ -1063,7 +1063,7 @@ def parse_email_headers(header, raw=False):
         email_addresses = email.utils.getaddresses(address_header)
 
         # This workaround addresses an issue with email addresses that have a comma in the display name
-        # but are not enclosed in quotation marks. In such cases, the email.utils.getaddresses function
+        # but are not enclosed in quotation marks (XSUP-41796). In such cases, the email.utils.getaddresses function
         # fails to parse the address correctly, as it expects display names with special characters
         # (like commas) to be wrapped in quotes, according to RFC 5322.
         if addr == 'From' and len(email_addresses) > 1:

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -67,21 +67,29 @@ def test_msg_parse_only_headers():
     assert isinstance(results.parsed_email, dict)
 
 
-def test_parse_email_headers():
+@pytest.mark.parametrize('headers, email_sender', [
+    ('To: <test@test.com> \nFrom: Services-Request September 06, 2024 <test@sender.com>',
+     ['<test@sender.com>']),
+    ('To: <test@test.com> \nFrom: Services-Request September 06 2024 <test@sender.com>',
+     ['Services-Request September 06 2024 <test@sender.com>']),
+    ('To: <test@test.com> \nFrom: "Services-Request September 06, 2024" <test@sender.com>',
+     ['Services-Request September 06, 2024 <test@sender.com>']),
+])
+def test_parse_email_headers(headers, email_sender):
     """
     Given:
-     - From header address
-       with a display names with comma not wrapped in quotes.
+     - From header address with a display names with comma not wrapped in quotes.
+     - From header address with a display names without comma and not wrapped in quotes.
+     - From header address with a display names with comma wrapped in quotes.
+
     When:
      - parsing the headers.
     Then:
      - Validate that the email was parsed correctly.
     """
-    headers = ("To: <test@test.com> \n"
-               "From: Services-Request September 06, 2024 <test@sender.com>")
     parsed_headers = parse_email_headers(headers)
 
-    assert parsed_headers.get('From') == ['<test@sender.com>']
+    assert parsed_headers.get('From') == email_sender
 
 
 @pytest.mark.parametrize('file_type', ['application/pkcs7-mime', 'macintosh hfs', 'message/rfc822', 'multipart/alternative',

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -3,7 +3,7 @@ import pytest
 from parse_emails.handle_eml import handle_eml, unfold
 from parse_emails.handle_msg import (DataModel, MsOxMessage,
                                      create_headers_map, get_msg_mail_format,
-                                     handle_msg)
+                                     handle_msg, parse_email_headers)
 from parse_emails.parse_emails import EmailParser
 
 
@@ -41,7 +41,7 @@ def test_msg_utf_encoded_subject():
 
 
 def test_msg_with_attachments():
-    test_path = 'parse_emails/tests/test_data/html_attachment.msg'
+    test_path = 'parse_emails/tests/test_data/Salary.msg'
 
     results = EmailParser(file_path=test_path, max_depth=3, parse_only_headers=False)
     results.parse()
@@ -65,6 +65,23 @@ def test_msg_parse_only_headers():
     results.parse()
 
     assert isinstance(results.parsed_email, dict)
+
+
+def test_parse_email_headers():
+    """
+    Given:
+     - From header address
+       with a display names with comma not wrapped in quotes.
+    When:
+     - parsing the headers.
+    Then:
+     - Validate that the email was parsed correctly.
+    """
+    headers = ("To: <test@test.com> \n"
+               "From: Services-Request September 06, 2024 <test@sender.com>")
+    parsed_headers = parse_email_headers(headers)
+
+    assert parsed_headers.get('From') == ['<test@sender.com>']
 
 
 @pytest.mark.parametrize('file_type', ['application/pkcs7-mime', 'macintosh hfs', 'message/rfc822', 'multipart/alternative',

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -41,7 +41,7 @@ def test_msg_utf_encoded_subject():
 
 
 def test_msg_with_attachments():
-    test_path = 'parse_emails/tests/test_data/Salary.msg'
+    test_path = 'parse_emails/tests/test_data/html_attachment.msg'
 
     results = EmailParser(file_path=test_path, max_depth=3, parse_only_headers=False)
     results.parse()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parse-emails"
-version = "0.1.29"
+version = "0.1.30"
 description = "Parses an email message file and extracts the data from it."
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/XSUP-41796

## Description
an issue with parsing email addresses that have commas in the display name but lack surrounding quotation marks, which leads to incorrect parsing by the email.utils.getaddresses function. According to RFC 5322, display names containing special characters (such as commas) must be enclosed in quotes. However, some email addresses do not follow this format, causing issues in extraction and validation.
Solution:
Implemented a secondary check on the parsed list to validate the extracted email addresses. Any invalid entries are removed, retaining only the valid email addresses.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
