### PR TITLE
Parse strict email address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+v0.1.32
+* Fixed an issue that prevented the from header address to being parsed on strict email address.
+
 v0.1.31
 * Fixed an issue that prevented the headers from being parsed correctly for MSG files (ASCII encoding).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 v0.1.32
-* Fixed a problem that prevented malformed email addresses from being parsed correctly.
+* Fixed a problem that prevented malformed email addresses from being parsed.
 
 v0.1.31
 * Fixed an issue that prevented the headers from being parsed correctly for MSG files (ASCII encoding).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 v0.1.32
-* Fixed a problem that prevented strict email addresses from parsing the from header (sender) address.
+* Fixed a problem that prevented malformed email addresses from being parsed correctly.
 
 v0.1.31
 * Fixed an issue that prevented the headers from being parsed correctly for MSG files (ASCII encoding).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 v0.1.32
-* Fixed an issue that prevented the from header address to being parsed on strict email address.
+* Fixed a problem that prevented strict email addresses from parsing the from header (sender) address.
 
 v0.1.31
 * Fixed an issue that prevented the headers from being parsed correctly for MSG files (ASCII encoding).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 v0.1.32
-* Fixed a problem that prevented malformed email addresses from being parsed.
+* Fixed an issue that prevented malformed email addresses from being parsed.
 
 v0.1.31
 * Fixed an issue that prevented the headers from being parsed correctly for MSG files (ASCII encoding).

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -5,6 +5,7 @@ import logging
 import os
 import quopri
 import re
+import sys
 import tempfile
 from base64 import b64decode
 from email import errors, message_from_string
@@ -430,7 +431,10 @@ def get_email_address(eml, entry):
                                               for current_eml_no_newline in eml.get_all(entry, [])]
     else:
         gel_all_values_from_email_by_entry = eml.get_all(entry, [])
-    addresses = getaddresses(gel_all_values_from_email_by_entry)
+    try:
+        addresses = getaddresses(gel_all_values_from_email_by_entry, strict=False)
+    except TypeError:
+        addresses = getaddresses(gel_all_values_from_email_by_entry)
     if addresses:
         res = [email_address for real_name, email_address in addresses if "@" in email_address]
         res = ', '.join(res)

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -5,7 +5,6 @@ import logging
 import os
 import quopri
 import re
-import sys
 import tempfile
 from base64 import b64decode
 from email import errors, message_from_string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parse-emails"
-version = "0.1.31"
+version = "0.1.32"
 description = "Parses an email message file and extracts the data from it."
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/XSUP-44516

## Description
Added support for strict email address ('@Jhon Due <info@example.com>') in python 3.11.10 for more info see the [docs](https://docs.python.org/3.11/library/email.utils.html#email.utils.getaddresses)

## Screenshots
<img width="801" alt="Screenshot 2024-12-08 at 1 46 41" src="https://github.com/user-attachments/assets/c7cc8753-7a4a-4d18-b91e-ba362219712e">


## Must have
- [ ] Tests
- [ ] Documentation
