### PR TITLE
Xsup 53425 parse email files v2 throws error when finding chinese characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 v0.1.43
-* Added a fallback for UnicodeDecodeErrors when parsing attachments. 
+* Added a fallback for UnicodeDecodeErrors when parsing attachments.
 
 v0.1.42
 * Fixed file-type resolution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+v0.1.43
+* Added a fallback for UnicodeDecodeErrors when parsing attachments. 
+
 v0.1.42
 * Fixed file-type resolution.
 

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -488,7 +488,7 @@ def get_attachment_filename(part):
             attachment_file_name = ''.join(
                 part.decode(charset or 'utf-8', errors='ignore')
                 for part, charset in decode_header(filename)
-            )
+            logger.debug(f"Failed to decode attachment {filename} will ignore bad bits")
     elif attachment_file_name is None and part.get('filename'):
         attachment_file_name = os.path.normpath(part.get('filename'))
         if os.path.isabs(attachment_file_name):

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -489,6 +489,7 @@ def get_attachment_filename(part):
                 part.decode(charset or 'utf-8', errors='ignore')
                 for part, charset in decode_header(filename)
             )
+            logger.debug(f"Failed to decode attachment {filename}, will ignore bad bits.")
     elif attachment_file_name is None and part.get('filename'):
         attachment_file_name = os.path.normpath(part.get('filename'))
         if os.path.isabs(attachment_file_name):

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -475,13 +475,20 @@ def get_attachment_filename(part):
     filename = part.get_filename()
     if filename:
         try:
-            attachment_file_name = str(make_header(decode_header(filename)))
+            decoded_header = decode_header(filename)
+            logger.debug(f"Decoded header for attachment: {decoded_header}")
+            attachment_file_name = str(make_header(decoded_header))
         except LookupError:
             if 'windows-874' in filename:
                 # If the file is encoded in windows-874 and contains the encoding
                 filename = filename.replace('windows-874', 'iso-8859-11')
                 attachment_file_name = str(make_header(decode_header(filename)))
-
+        except UnicodeDecodeError:
+            # fallback: ignore bad bits so we get the rest of the name
+            attachment_file_name = ''.join(
+                part.decode(charset or 'utf-8', errors='ignore')
+                for part, charset in decode_header(filename)
+            )
     elif attachment_file_name is None and part.get('filename'):
         attachment_file_name = os.path.normpath(part.get('filename'))
         if os.path.isabs(attachment_file_name):

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -488,7 +488,7 @@ def get_attachment_filename(part):
             attachment_file_name = ''.join(
                 part.decode(charset or 'utf-8', errors='ignore')
                 for part, charset in decode_header(filename)
-            logger.debug(f"Failed to decode attachment {filename} will ignore bad bits")
+            logger.debug(f"Failed to decode attachment {filename}, will ignore bad bits.")
     elif attachment_file_name is None and part.get('filename'):
         attachment_file_name = os.path.normpath(part.get('filename'))
         if os.path.isabs(attachment_file_name):

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -488,7 +488,7 @@ def get_attachment_filename(part):
             attachment_file_name = ''.join(
                 part.decode(charset or 'utf-8', errors='ignore')
                 for part, charset in decode_header(filename)
-            logger.debug(f"Failed to decode attachment {filename}, will ignore bad bits.")
+            )
     elif attachment_file_name is None and part.get('filename'):
         attachment_file_name = os.path.normpath(part.get('filename'))
         if os.path.isabs(attachment_file_name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parse-emails"
-version = "0.1.42"
+version = "0.1.43"
 description = "Parses an email message file and extracts the data from it."
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION

## Related Issues
fixes: [XSUP-53425](https://jira-dc.paloaltonetworks.com/browse/XSUP-53425)

## Description
Adding a fallback to when a character is not decodable.  
