### PR TITLE
Fix double base64 decoding of embedded email attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+v0.1.48
+* Fixed an issue where embedded EML attachments with base64 encoding were being double-decoded, causing parsing failures.
+
 v0.1.47
 * Fixed an issue where the headers_map['Subject'] not match 'Subject'.
 

--- a/parse_emails/handle_eml.py
+++ b/parse_emails/handle_eml.py
@@ -111,49 +111,81 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
         while parts:
             part = parts.pop()
 
-            logger.debug(f'Iterating over parts. Current part: {part.get_content_type()=}')
-            if (part.is_multipart() or part.get_content_type().startswith('multipart')) \
-                    and "attachment" not in part.get("Content-Disposition", ""):
-                parts += [part_ for part_ in part.get_payload() if isinstance(part_, email.message.Message)]
+            logger.debug(
+                f"Iterating over parts. Current part: {part.get_content_type()=}"
+            )
+            if (
+                part.is_multipart() or part.get_content_type().startswith("multipart")
+            ) and "attachment" not in part.get("Content-Disposition", ""):
+                parts += [
+                    part_
+                    for part_ in part.get_payload()
+                    if isinstance(part_, email.message.Message)
+                ]
 
-            elif part.get_filename()\
-                    or "attachment" in part.get("Content-Disposition", "")\
-                    or part.get("X-Attachment-Id")\
-                    or ("image" in part.get("Content-Type", '') and part.get("Content-Transfer-Encoding") == "base64"):
+            elif (
+                part.get_filename()
+                or "attachment" in part.get("Content-Disposition", "")
+                or part.get("X-Attachment-Id")
+                or (
+                    "image" in part.get("Content-Type", "")
+                    and part.get("Content-Transfer-Encoding") == "base64"
+                )
+            ):
 
-                attachment_content_id = part.get('Content-ID')
-                attachment_content_disposition = part.get('Content-Disposition')
+                attachment_content_id = part.get("Content-ID")
+                attachment_content_disposition = part.get("Content-Disposition")
                 attachment_file_name = get_attachment_filename(part)
 
-                if attachment_file_name is None and part.get('filename'):
-                    attachment_file_name = os.path.normpath(part.get('filename'))
+                if attachment_file_name is None and part.get("filename"):
+                    attachment_file_name = os.path.normpath(part.get("filename"))
                     if os.path.isabs(attachment_file_name):
                         attachment_file_name = os.path.basename(attachment_file_name)
 
-                if "message/rfc822" in part.get("Content-Type", "") \
-                        or ("application/octet-stream" in part.get("Content-Type", "") and
-                            attachment_file_name.endswith(".eml")):
+                if "message/rfc822" in part.get("Content-Type", "") or (
+                    "application/octet-stream" in part.get("Content-Type", "")
+                    and attachment_file_name.endswith(".eml")
+                ):
 
                     # .eml files
                     file_content = ""  # type: str
-                    base64_encoded = "base64" in part.get("Content-Transfer-Encoding", "")
+                    base64_encoded = "base64" in part.get(
+                        "Content-Transfer-Encoding", ""
+                    )
 
-                    if isinstance(part.get_payload(), list) and len(part.get_payload()) > 0:
-                        if attachment_file_name is None or attachment_file_name == "" or attachment_file_name == 'None':
+                    if (
+                        isinstance(part.get_payload(), list)
+                        and len(part.get_payload()) > 0
+                    ):
+                        if (
+                            attachment_file_name is None
+                            or attachment_file_name == ""
+                            or attachment_file_name == "None"
+                        ):
                             # in case there is no filename for the eml
                             # we will try to use mail subject as file name
                             # Subject will be in the email headers
-                            attachment_name = part.get_payload()[0].get('Subject', "no_name_mail_attachment")
-                            attachment_file_name = f'{attachment_name}.eml'
+                            attachment_name = part.get_payload()[0].get(
+                                "Subject", "no_name_mail_attachment"
+                            )
+                            attachment_file_name = f"{attachment_name}.eml"
 
                         file_content = part.get_payload()[0].as_string().strip()
-                        if base64_encoded:
+
+                        # Check if the content is actually base64 encoded by looking for email headers
+                        # If it has email headers (From:, To:, Subject:), it's already decoded
+                        # If it doesn't have headers and looks like base64, we need to decode it
+                        has_email_headers = any(
+                            header in file_content[:500]
+                            for header in ["From:", "To:", "Subject:", "Content-Type:"]
+                        )
+
+                        if base64_encoded and not has_email_headers:
+                            # Content is still base64 encoded, need to decode it
                             try:
                                 file_content = b64decode(file_content)
-
-                            except TypeError:
-                                pass  # In case the file is a string, decode=True for get_payload is not working
-                            except binascii.Error:
+                            except (TypeError, binascii.Error):
+                                # If decode fails, keep the original content
                                 pass
 
                     elif isinstance(part.get_payload(), str):
@@ -226,11 +258,20 @@ def handle_eml(file_path, b64=False, file_name=None, parse_only_headers=False, m
                             try:
                                 f.write(file_content)
                                 f.close()
-                                inner_msg, inner_attached_emails, attached_eml = handle_msg(f.name, attachment_file_name, False,
-                                                                                            max_depth - 1, original_depth)
+                                inner_msg, inner_attached_emails, attached_eml = (
+                                    handle_msg(
+                                        f.name,
+                                        attachment_file_name,
+                                        False,
+                                        max_depth - 1,
+                                        original_depth,
+                                    )
+                                )
                                 if attached_eml:
-                                    attached_eml = parse_inner_eml(attachments=attached_eml,
-                                                                   original_depth=original_depth)
+                                    attached_eml = parse_inner_eml(
+                                        attachments=attached_eml,
+                                        original_depth=original_depth,
+                                    )
                                     attached_emails += attached_eml
                                 if inner_msg:
                                     inner_msg['ParentFileName'] = file_name

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -26,7 +26,7 @@ def test_parse_embedded_base64_eml_eml():
      - Validate that both emails are parsed (outer + inner with malformed content)
      - Verify the subjects are correct
     """
-    test_path = '/Users/meichler/dev/demisto/parse-emails/parse_emails/tests/test_data/embedded_base64_eml.eml'
+    test_path = 'parse_emails/tests/test_data/embedded_base64_eml.eml'
 
     email_parser = EmailParser(file_path=test_path, max_depth=2)
     results = email_parser.parse()

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -16,7 +16,7 @@ def test_parse_emails():
     assert results[0]['Subject'] == 'Fwd: test - inner attachment eml (base64)'
 
 
-def test_parse_noname_eml():
+def test_parse_embedded_base64_eml_eml():
     """
     Given:
      - noname.eml file containing a malicious/corrupted embedded EML attachment
@@ -26,16 +26,16 @@ def test_parse_noname_eml():
      - Validate that both emails are parsed (outer + inner with malformed content)
      - Verify the subjects are correct
     """
-    test_path = "noname.eml"
+    test_path = '/Users/meichler/dev/demisto/parse-emails/parse_emails/tests/test_data/embedded_base64_eml.eml'
 
     email_parser = EmailParser(file_path=test_path, max_depth=2)
     results = email_parser.parse()
     assert len(results) == 2
     assert (
         results[0]["Subject"]
-        == "Fax Document Recieved for Edf Remote CSID:a6930c8e18426e8588747786c6aee7c2"
+        == "Fax Document"
     )
-    assert results[1]["Subject"] == "Edf Fax Document Recieved for 17/12"
+    assert results[1]["Subject"] == "Inner Fax"
 
 
 def test_msg_html_with_attachments():

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -16,6 +16,28 @@ def test_parse_emails():
     assert results[0]['Subject'] == 'Fwd: test - inner attachment eml (base64)'
 
 
+def test_parse_noname_eml():
+    """
+    Given:
+     - noname.eml file containing a malicious/corrupted embedded EML attachment
+    When:
+     - parsing with max_depth=2 to parse both outer and inner emails
+    Then:
+     - Validate that both emails are parsed (outer + inner with malformed content)
+     - Verify the subjects are correct
+    """
+    test_path = "noname.eml"
+
+    email_parser = EmailParser(file_path=test_path, max_depth=2)
+    results = email_parser.parse()
+    assert len(results) == 2
+    assert (
+        results[0]["Subject"]
+        == "Fax Document Recieved for Edf Remote CSID:a6930c8e18426e8588747786c6aee7c2"
+    )
+    assert results[1]["Subject"] == "Edf Fax Document Recieved for 17/12"
+
+
 def test_msg_html_with_attachments():
     msg = MsOxMessage('parse_emails/tests/test_data/html_attachment.msg')
     assert msg is not None

--- a/parse_emails/tests/parse_emails_test.py
+++ b/parse_emails/tests/parse_emails_test.py
@@ -31,10 +31,7 @@ def test_parse_embedded_base64_eml_eml():
     email_parser = EmailParser(file_path=test_path, max_depth=2)
     results = email_parser.parse()
     assert len(results) == 2
-    assert (
-        results[0]["Subject"]
-        == "Fax Document"
-    )
+    assert results[0]["Subject"] == "Fax Document"
     assert results[1]["Subject"] == "Inner Fax"
 
 

--- a/parse_emails/tests/test_data/embedded_base64_eml.eml
+++ b/parse_emails/tests/test_data/embedded_base64_eml.eml
@@ -1,0 +1,37 @@
+From: jr@example.com
+To: user@edf.fr
+Subject: Fax Document
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="===============123456=="
+
+--===============123456==
+Content-Type: text/plain
+
+Outer email body.
+
+--===============123456==
+Content-Type: message/rfc822
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="fax.eml"
+
+From: fax@example.com
+To: user@edf.fr
+Subject: Inner Fax
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="_001_INNER_"
+
+--_001_INNER_
+Content-Type: text/plain
+
+Inner email body.
+
+--_001_INNER_
+Content-Type: text/html
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="fax.shtml"
+
+PGh0bWw+PGJvZHk+PHNjcmlwdD5hbGVydCgnSGVsbG8nKTs8L3NjcmlwdD48L2JvZHk+PC9odG1sPg==
+
+--_001_INNER_--
+
+--===============123456==--

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parse-emails"
-version = "0.1.47"
+version = "0.1.48"
 description = "Parses an email message file and extracts the data from it."
 authors = ["Demisto"]
 license = "MIT"


### PR DESCRIPTION

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: https://jira-dc.paloaltonetworks.com/browse/XSUP-60906

## Description
Added a check in parse_emails/handle_eml.py - before base64 decoding, check if the content already has email headers (From:, To:, Subject:). If it does, it's already decoded. If not, then decode it.

## Screenshots
Paste here any images that will help the reviewer

## Must have
- [ ] Tests
- [ ] Documentation
